### PR TITLE
fixed typo in redis.conf.erb so that defining requirepass will now work

### DIFF
--- a/templates/default/redis.conf.erb
+++ b/templates/default/redis.conf.erb
@@ -162,7 +162,7 @@ slave-serve-stale-data yes
 # use a very strong password otherwise it will be very easy to break.
 #
 <% if @conf["requirepass"] %>
-requirepass <% @conf["requirepass"] %>
+requirepass <%= @conf["requirepass"] %>
 <% end %>
 
 # Command renaming.


### PR DESCRIPTION
Hello!

I was trying out your cookbook when I noticed that trying to specify a requirepass wasn't working.  Here's a one line fix.

Chris
